### PR TITLE
electron-packager version update, builds on Node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "electron": "^1.7.6"
   },
   "devDependencies": {
-    "electron-packager": "^9.0.1"
+    "electron-packager": "^12.1.2"
   }
 }


### PR DESCRIPTION
Node version check fails when running Node 10 in electron-packager 9.0.1, fixed in 12.1.2